### PR TITLE
Add basic CI checks and fix lint/type errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Lint with ruff
+        run: uv run ruff check .
+
+      - name: Type check with mypy
+        run: uv run mypy .
+
+      - name: Basic execution check
+        run: uv run python -c "import ball_screen, otel_test, sshow_tools"

--- a/ball.ipynb
+++ b/ball.ipynb
@@ -38,10 +38,10 @@
     }
    ],
    "source": [
+    "from time import sleep\n",
+    "\n",
     "from ball_screen.ipywidgets import display_ball_animation\n",
     "from ball_screen.protocols import BallScreen\n",
-    "\n",
-    "from time import sleep\n",
     "\n",
     "BALL_SIZE = 10\n",
     "BALL_SPEED = 2\n",

--- a/ball_screen/ipywidgets.py
+++ b/ball_screen/ipywidgets.py
@@ -55,7 +55,7 @@ def display_ball_animation(
     canvas = RoughCanvas(width=width, height=height)
     screen = _CanvasBallScreen(width, height, canvas, stop_event)
 
-    def start_thread(*_):
+    def start_thread(*_: object) -> None:
         nonlocal thread
         print("Starting thread")
         thread = Thread(target=anim_func, kwargs={"screen": screen})
@@ -63,10 +63,11 @@ def display_ball_animation(
         start_btn.disabled = True
         stop_btn.disabled = False
 
-    def stop_thread(*_):
+    def stop_thread(*_: object) -> None:
         nonlocal thread
         stop_event.set()
-        thread.join()
+        if thread is not None:
+            thread.join()
         print("Thread stopped")
         thread = None
         stop_event.clear()

--- a/ball_screen/protocols.py
+++ b/ball_screen/protocols.py
@@ -1,6 +1,6 @@
 """Protocols for bouncing ball displays."""
-from typing import Protocol, runtime_checkable
 from abc import abstractmethod
+from typing import Protocol, runtime_checkable
 
 
 @runtime_checkable

--- a/otel_test.ipynb
+++ b/otel_test.ipynb
@@ -471,8 +471,8 @@
     }
    ],
    "source": [
-    "from pathlib import Path\n",
     "from os import chdir\n",
+    "from pathlib import Path\n",
     "\n",
     "import panel\n",
     "\n",
@@ -658,6 +658,7 @@
    ],
    "source": [
     "import sys\n",
+    "\n",
     "sys.path"
    ]
   }

--- a/otel_test/counter.py
+++ b/otel_test/counter.py
@@ -1,10 +1,10 @@
 from collections import Counter
-from typing import Mapping
+from collections.abc import Mapping
 
 from fastapi import FastAPI
 
 app = FastAPI()
-counter = Counter()
+counter: Counter[str] = Counter()
 
 
 @app.get("/{counter_name}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,8 +70,8 @@ build-backend = "setuptools.build_meta"
 # uv Package Manager Configuration
 # =============================================================================
 # Development dependencies with version constraints for stability
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "pytest>=7.0",      # Modern pytest features
     "pytest-cov>=4.0",  # Recent coverage features
     "black>=23.0",      # Stable formatting
@@ -143,6 +143,7 @@ strict_equality = true             # Use strict equality checks
 line-length = 88
 target-version = "py310"
 
+[tool.ruff.lint]
 # DECISION: Enable comprehensive but practical rule set
 # Focus on errors, style, and modern Python practices
 select = [
@@ -163,7 +164,7 @@ ignore = [
 ]
 
 # File-specific rule exceptions
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]  # Allow unused imports in __init__.py files
 
 # =============================================================================

--- a/sshow_tools/terminal_runner.py
+++ b/sshow_tools/terminal_runner.py
@@ -1,12 +1,13 @@
-from subprocess import Popen, PIPE, DEVNULL
-from selectors import DefaultSelector, EVENT_READ
-from threading import Thread
 import os
+from selectors import EVENT_READ, DefaultSelector
+from subprocess import DEVNULL, PIPE, Popen
+from threading import Thread
+from typing import Any
 
 import panel
-import panel.widgets
-import panel.viewable
 import panel.pane
+import panel.viewable
+import panel.widgets
 
 
 class TerminalRunner(panel.viewable.Viewer):
@@ -28,14 +29,14 @@ class TerminalRunner(panel.viewable.Viewer):
             height=70,
             margin=(5, 10, 0, 10),
         )
-        self._process = None
-        self._thread = None
+        self._process: Popen[Any] | None = None
+        self._thread: Thread | None = None
         self._args = args
 
         self._run_btn = panel.widgets.Button(
-            name=self.PLAY_LABEL, 
-            width=30, 
-            height=30, 
+            name=self.PLAY_LABEL,
+            width=30,
+            height=30,
             sizing_mode="fixed",
             margin=(5, 10, 5, 5),
         )
@@ -43,7 +44,7 @@ class TerminalRunner(panel.viewable.Viewer):
         self._panel = panel.Column(
             panel.Row(
                 panel.pane.Markdown(
-                    f"```bash\n{args}\n```", 
+                    f"```bash\n{args}\n```",
                     sizing_mode="stretch_both",
                     margin=10,
                 ),
@@ -52,14 +53,14 @@ class TerminalRunner(panel.viewable.Viewer):
                 background="#f8f8f8",
                 # style={"border": "1px solid #f0f0f0"},
                 margin=(0, 25, 0, 10),
-            ), 
+            ),
             self._terminal,
             width=160,
             height=80,
             sizing_mode="scale_both"
         )
 
-    def _on_btn_click(self, event):
+    def _on_btn_click(self, event: Any) -> None:
         if self._thread:
             if self._process:
                 self._process.terminate()
@@ -67,7 +68,7 @@ class TerminalRunner(panel.viewable.Viewer):
             self._thread = Thread(target=self._stream_proc_to_output)
             self._thread.start()
 
-    def __panel__(self):
+    def __panel__(self) -> panel.Column:
         return self._panel
 
     def _stream_proc_to_output(self) -> None:
@@ -91,13 +92,14 @@ class TerminalRunner(panel.viewable.Viewer):
                         selector.register(self._process.stderr, EVENT_READ)
                     while selector.get_map():
                         ready = selector.select()
-                        for key, events in ready:
+                        for key, _events in ready:
                             buf = os.read(key.fd, 10)
                             if buf:
                                 self._terminal.write(buf.decode())
                             else:
                                 selector.unregister(key.fileobj)
-                                key.fileobj.close()
+                                if hasattr(key.fileobj, "close"):
+                                    key.fileobj.close()
         finally:
             self._terminal.write("\033[31;1mTerminated\033[0m\n")
             self._process = None


### PR DESCRIPTION
This PR adds basic CI checks to the repository using GitHub Actions. It also includes several fixes for linting and type errors that were discovered during the process of setting up the CI.

Key changes:
- Created `.github/workflows/ci.yml` which runs on push and pull requests to `main`. It installs dependencies using `uv`, runs `ruff check`, `mypy`, and a basic import check.
- Updated `pyproject.toml`:
  - Migrated `tool.uv.dev-dependencies` to `dependency-groups.dev`.
  - Moved `ruff` settings under `tool.ruff.lint` as per modern `ruff` configuration.
- Fixed code quality issues:
  - Added missing type annotations in `ball_screen/ipywidgets.py`, `otel_test/counter.py`, and `sshow_tools/terminal_runner.py`.
  - Resolved `ruff` warnings such as unorganized imports, unused variables, and trailing whitespace.
  - Fixed `mypy` errors related to `None` type handling and missing attributes.
  - Ensured that `sshow_tools/terminal_runner.py` correctly handles process termination and thread lifecycle.

These changes ensure that the codebase maintains a consistent quality level and that regressions are caught early in the development process.

Fixes #56

---
*PR created automatically by Jules for task [15090452265682086873](https://jules.google.com/task/15090452265682086873) started by @ifireball*